### PR TITLE
Bug fix for held stitches & update cable pattern

### DIFF
--- a/KnittingChartPreview/Assets/Scripts/BaseStitch.cs
+++ b/KnittingChartPreview/Assets/Scripts/BaseStitch.cs
@@ -108,7 +108,6 @@ namespace YarnGenerator
                     {
                         Loop[] baseStitchConsumed = loop.producedBy.loopsConsumed;
                         Loop baseStitchConsumedLoop = baseStitchConsumed[0];
-                        Debug.Log($"loop.producedBy: {loop.producedBy.rowIndex}.  holdDirection {holdDirection}");
                         if (holdDirection != HoldDirection.None)
                         {
                             float offset = loop.GetIndex() - baseStitchConsumedLoop.GetIndex();

--- a/KnittingChartPreview/Assets/Scripts/Editor/KnittingPatternEditor.cs
+++ b/KnittingChartPreview/Assets/Scripts/Editor/KnittingPatternEditor.cs
@@ -22,8 +22,8 @@ namespace YarnGenerator
         // Number of cable blocks per row
         public int cableStitchesPerRow = 10;
 
-        // size of cable (eg for 2x2)
-        public int cableBlockSize = 4;
+        // type of cable block (eg for 2x2)
+        public int cableBlockType = (int) StitchType.Cable2Lo2RStitch;
 
         // Number of rows between cable stitches (knit stitches in between) 
         public int cableLength = 4;
@@ -69,7 +69,7 @@ namespace YarnGenerator
                 nRows,
                 padding,
                 cableStitchesPerRow,
-                cableBlockSize,
+                (StitchType)cableBlockType,
                 cableSeparationSize,
                 cableLength);
         }
@@ -87,8 +87,10 @@ namespace YarnGenerator
         GUILayout.Label("Cable Pattern Options", EditorStyles.boldLabel);
         cableStitchesPerRow = EditorGUILayout.IntSlider(
             "Cables Per Row", cableStitchesPerRow, 1, 10);
-        cableBlockSize = EditorGUILayout.IntPopup(
-            "Cable Block Size", cableBlockSize, new string[] {"1x1", "2x2"}, new int[] {2, 4});
+        cableBlockType = EditorGUILayout.IntPopup(
+            "Cable Block Size", cableBlockType,
+            new string[] {"1x1", "1x2", "2x2"},
+            new int[] {(int) StitchType.Cable1Lo1RStitch, (int) StitchType.Cable1Ro2LStitch, (int) StitchType.Cable2Lo2RStitch});
         cableLength = EditorGUILayout.IntSlider(
             "Cable Length", cableLength, 1, 8);
         cableSeparationSize = EditorGUILayout.IntSlider(

--- a/KnittingChartPreview/Assets/Scripts/Editor/KnittingPatternEditor.cs
+++ b/KnittingChartPreview/Assets/Scripts/Editor/KnittingPatternEditor.cs
@@ -33,10 +33,10 @@ namespace YarnGenerator
 
         // number of purl stitches on either side
         public int padding = 2;
-        
+
         // number of stitches per row, for basic pattern
         public int basicStitchesPerRow = 8;
-        
+
         // number of stitches per row for lace pattern
         public int laceStitchesPerRow = 30;
 
@@ -65,95 +65,87 @@ namespace YarnGenerator
 
         Pattern GetCablePattern()
         {
-           return new CablePattern(
+            return new CablePattern(
                 nRows,
                 padding,
                 cableStitchesPerRow,
-                (StitchType)cableBlockType,
+                (StitchType) cableBlockType,
                 cableSeparationSize,
                 cableLength);
         }
 
         void OnGUI()
-    {
-        GUILayout.Label("Basic Preview Options", EditorStyles.boldLabel);
-        nRows = EditorGUILayout.IntSlider(
-            "# Rows", nRows, 1, 50);
-        yarnWidth = EditorGUILayout.Slider(
-            "Yarn Width", yarnWidth, 0.0001f, 0.33f);
-        material = (Material) EditorGUILayout.ObjectField(material, typeof(Material));
-        
-        GUILayout.Space(10);
-        GUILayout.Label("Cable Pattern Options", EditorStyles.boldLabel);
-        cableStitchesPerRow = EditorGUILayout.IntSlider(
-            "Cables Per Row", cableStitchesPerRow, 1, 10);
-        cableBlockType = EditorGUILayout.IntPopup(
-            "Cable Block Size", cableBlockType,
-            new string[] {"1x1", "1x2", "2x2"},
-            new int[] {(int) StitchType.Cable1Lo1RStitch, (int) StitchType.Cable1Ro2LStitch, (int) StitchType.Cable2Lo2RStitch});
-        cableLength = EditorGUILayout.IntSlider(
-            "Cable Length", cableLength, 1, 8);
-        cableSeparationSize = EditorGUILayout.IntSlider(
-            "Cable Separation Size", cableSeparationSize, 0, 8);
-        padding = EditorGUILayout.IntSlider(
-            "Row padding", padding, 0, 8);
+        {
+            GUILayout.Label("Basic Preview Options", EditorStyles.boldLabel);
+            nRows = EditorGUILayout.IntSlider(
+                "# Rows", nRows, 1, 50);
+            yarnWidth = EditorGUILayout.Slider(
+                "Yarn Width", yarnWidth, 0.0001f, 0.33f);
+            material = (Material) EditorGUILayout.ObjectField(material, typeof(Material));
+
+            GUILayout.Space(10);
+            GUILayout.Label("Cable Pattern Options", EditorStyles.boldLabel);
+            cableStitchesPerRow = EditorGUILayout.IntSlider(
+                "Cables Per Row", cableStitchesPerRow, 1, 10);
+            cableBlockType = EditorGUILayout.IntPopup(
+                "Cable Block Size", cableBlockType,
+                new string[] {"1x1", "1x2", "2x2"},
+                new int[]
+                {
+                    (int) StitchType.Cable1Lo1RStitch, (int) StitchType.Cable1Ro2LStitch,
+                    (int) StitchType.Cable2Lo2RStitch
+                });
+            cableLength = EditorGUILayout.IntSlider(
+                "Cable Length", cableLength, 1, 8);
+            cableSeparationSize = EditorGUILayout.IntSlider(
+                "Cable Separation Size", cableSeparationSize, 0, 8);
+            padding = EditorGUILayout.IntSlider(
+                "Row padding", padding, 0, 8);
 
 
-        if (GUILayout.Button("Generate Cable Pattern"))
-        {
-            if (yarnWidth > 1.0f / 3.0f)
+            if (GUILayout.Button("Generate Cable Pattern"))
             {
-                Debug.LogError("Yarn Width needs to be less than 1/6 the stitch length"
-                               + $"Please choose a yarn width less than {2.0f / 6.0f}");
-                return;
-            }
-            
-            Pattern pattern = GetCablePattern();
-            pattern.RenderPreview(yarnWidth, material);
-        }
-        
-        GUILayout.Space(10);
-        GUILayout.Label("Basic Pattern Options", EditorStyles.boldLabel);
-        basicStitchesPerRow = EditorGUILayout.IntSlider(
-            "Stitches Per Row", basicStitchesPerRow, 1, 10);
-        
-        if (GUILayout.Button("Generate Basic Pattern"))
-        {
-            if (yarnWidth > 1.0f / 3.0f)
-            {
-                Debug.LogError("Yarn Width needs to be less than 1/6 the stitch length"
-                               + $"Please choose a yarn width less than {2.0f / 6.0f}");
-                return;
-            }
-            
-            Pattern pattern = GetBasicPattern();
-            pattern.RenderPreview(yarnWidth, material);
-        }
+                if (yarnWidth > 1.0f / 3.0f)
+                {
+                    Debug.LogError("Yarn Width needs to be less than 1/6 the stitch length"
+                                   + $"Please choose a yarn width less than {2.0f / 6.0f}");
+                    return;
+                }
 
-        if (GUILayout.Button("Generate Lace Pattern"))
-        {
-            if (yarnWidth > 1.0f / 3.0f)
-            {
-                Debug.LogError("Yarn Width needs to be less than 1/6 the stitch length"
-                               + $"Please choose a yarn width less than {2.0f / 6.0f}");
-                return;
+                Pattern pattern = GetCablePattern();
+                pattern.RenderPreview(yarnWidth, material);
             }
-            
-            Pattern pattern = GetLacePattern();
-            pattern.RenderPreview(yarnWidth, material);
-        }
-        if (GUILayout.Button("Generate Cable Practice Pattern"))
-        {
-            if (yarnWidth > 1.0f / 3.0f)
+
+            GUILayout.Space(10);
+            GUILayout.Label("Basic Pattern Options", EditorStyles.boldLabel);
+            basicStitchesPerRow = EditorGUILayout.IntSlider(
+                "Stitches Per Row", basicStitchesPerRow, 1, 10);
+
+            if (GUILayout.Button("Generate Basic Pattern"))
             {
-                Debug.LogError("Yarn Width needs to be less than 1/6 the stitch length"
-                               + $"Please choose a yarn width less than {2.0f / 6.0f}");
-                return;
+                if (yarnWidth > 1.0f / 3.0f)
+                {
+                    Debug.LogError("Yarn Width needs to be less than 1/6 the stitch length"
+                                   + $"Please choose a yarn width less than {2.0f / 6.0f}");
+                    return;
+                }
+
+                Pattern pattern = GetBasicPattern();
+                pattern.RenderPreview(yarnWidth, material);
             }
-            
-            Pattern pattern = GetCablePracticePattern();
-            pattern.RenderPreview(yarnWidth, material);
+
+            if (GUILayout.Button("Generate Lace Pattern"))
+            {
+                if (yarnWidth > 1.0f / 3.0f)
+                {
+                    Debug.LogError("Yarn Width needs to be less than 1/6 the stitch length"
+                                   + $"Please choose a yarn width less than {2.0f / 6.0f}");
+                    return;
+                }
+
+                Pattern pattern = GetLacePattern();
+                pattern.RenderPreview(yarnWidth, material);
+            }
         }
     }
-}
 }

--- a/KnittingChartPreview/Assets/Scripts/Pattern.cs
+++ b/KnittingChartPreview/Assets/Scripts/Pattern.cs
@@ -666,8 +666,7 @@ namespace YarnGenerator
 
         int GetCableBlockSize(StitchType cableBlockType)
         {
-            StitchInfo stitchInfo = StitchInfo.GetStitchInfo(this.cableBlockType);
-            Debug.Log($"stitchType: {cableBlockType}, stitchInfo.nBaseStitches: {stitchInfo.nBaseStitches}");
+            StitchInfo stitchInfo = StitchInfo.GetStitchInfo(cableBlockType);
             return stitchInfo.nBaseStitches;
         }
 

--- a/KnittingChartPreview/Assets/Scripts/Pattern.cs
+++ b/KnittingChartPreview/Assets/Scripts/Pattern.cs
@@ -641,6 +641,7 @@ namespace YarnGenerator
         private int padding;
         private int cableStitchesPerRow;
         private int cableBlockSize;
+        private StitchType cableBlockType;
         private int cableSeparationSize;
         private int cableLength;
 
@@ -648,7 +649,7 @@ namespace YarnGenerator
             int nRows,
             int padding,
             int cableStitchesPerRow,
-            int cableBlockSize,
+            StitchType cableBlockType,
             int cableSeparationSize,
             int cableLength
         ): base(nRows)
@@ -656,10 +657,18 @@ namespace YarnGenerator
             this.nRows = nRows;
             this.padding = padding;
             this.cableStitchesPerRow = cableStitchesPerRow;
-            this.cableBlockSize = cableBlockSize;
+            this.cableBlockType = cableBlockType;
+            this.cableBlockSize = GetCableBlockSize(cableBlockType);
             this.cableSeparationSize = cableSeparationSize;
             this.cableLength = cableLength;
             GetPatternRows();
+        }
+
+        int GetCableBlockSize(StitchType cableBlockType)
+        {
+            StitchInfo stitchInfo = StitchInfo.GetStitchInfo(this.cableBlockType);
+            Debug.Log($"stitchType: {cableBlockType}, stitchInfo.nBaseStitches: {stitchInfo.nBaseStitches}");
+            return stitchInfo.nBaseStitches;
         }
 
         int GetTotalStitchesPerRow()
@@ -682,9 +691,14 @@ namespace YarnGenerator
 
             Row prevRow = null;
             Row[] rows = new Row[nRows];
+
             for (int rowNumber = 0; rowNumber < nRows; rowNumber++)
             {
-                StitchType[] stitches = new StitchType[stitchesPerRow];
+                StitchType[] stitches = new StitchType[stitchesPerRow];;
+                if (rowNumber % cableLength != 0)
+                {
+                    stitches = new StitchType[stitchesPerRow + (cableBlockSize) * cableStitchesPerRow];
+                }
 
                 int stitchIndex = 0;
                 for (int i = 0; i < padding; i++)
@@ -693,36 +707,22 @@ namespace YarnGenerator
                     stitchIndex += 1;
                 }
 
-
-                StitchType cableStitchType;
-                StitchType nonCableStitchType;
-                switch (cableBlockSize)
-                {
-                    case 2:
-                        cableStitchType = StitchType.Cable1Lo1RStitch;
-                        nonCableStitchType = StitchType.CableKnitStitch;
-                        break;
-                    case 4:
-                        cableStitchType = StitchType.Cable2Lo2RStitch;
-                        nonCableStitchType = StitchType.CableKnitStitch4;
-                        break;
-                    default:
-                        cableStitchType = StitchType.Cable2Lo2RStitch;
-                        nonCableStitchType = StitchType.CableKnitStitch;
-                        break;
-                }
                 for (int i = 0; i < cableStitchesPerRow; i++)
                 {
                     if (rowNumber % cableLength == 0)
                     {
-                        stitches[stitchIndex] = cableStitchType;
+                        stitches[stitchIndex] = cableBlockType;
+                        stitchIndex += 1;
                     }
                     else
                     {
-                        stitches[stitchIndex] = nonCableStitchType;
+                        for (int j = 0; j < cableBlockSize; j++)
+                        {
+                            stitches[stitchIndex] = StitchType.KnitStitch;
+                            stitchIndex += 1;
+                        }
                     }
 
-                    stitchIndex += 1;
                     if (cableStitchesPerRow > 1 && i < cableStitchesPerRow - 1)
                     {
                         for (int j = 0; j < cableSeparationSize; j++)

--- a/KnittingChartPreview/Assets/Scripts/Stitch.cs
+++ b/KnittingChartPreview/Assets/Scripts/Stitch.cs
@@ -96,7 +96,7 @@ namespace YarnGenerator
             int loopIndexConsumed1 = 0;
             int loopIndexProduced1 = 0;
 
-            // Work through each of the baseStitches produced in the baseStitchTypeList
+            // Work through each of the baseStitches in the baseStitchTypeList
             for (int baseStitchIndex = 0; baseStitchIndex < this.stitchInfo.nBaseStitches; baseStitchIndex++)
             {
                 BaseStitchType baseStitchType = stitchInfo.baseStitchInfoList[baseStitchIndex].BaseStitchType;
@@ -106,11 +106,11 @@ namespace YarnGenerator
 
                 HoldDirection holdDirection = GetHoldDirection(baseStitchIndex);
 
-                baseStitches[baseStitchIndex] = new BaseStitch(
+                baseStitches[baseStitchIndex + GetIndexOffset(baseStitchIndex)] = new BaseStitch(
                     baseStitchInfo,
                     rowIndex,
                     stitchIndex,
-                    baseStitchIndex + GetIndexOffset(baseStitchIndex),
+                    baseStitchIndex,
                     this.loopIndexConsumed + loopIndexConsumed1,
                     this.loopIndexProduced + loopIndexProduced1 + GetIndexOffset(baseStitchIndex),
                     holdDirection,
@@ -120,21 +120,6 @@ namespace YarnGenerator
                 loopIndexConsumed1 += baseStitchInfo.nLoopsConsumed;
                 loopIndexProduced1 += baseStitchInfo.nLoopsProduced;
             }
-        }
-
-        public BaseStitch GetOrderedBaseStitch(int baseStitchIndex)
-        {
-            // If there are no held stitches, just return the base stitch
-            // at location baseStitchIndex
-            if (stitchInfo.held == 0)
-            {
-                return baseStitches[baseStitchIndex];
-            }
-            if (IsStitchHeld(baseStitchIndex))
-            {
-                return baseStitches[baseStitchIndex + stitchInfo.held];
-            }
-            return baseStitches[baseStitchIndex - stitchInfo.held];
         }
 
         public int GetIndexOffset(int baseStitchIndex)
@@ -151,7 +136,7 @@ namespace YarnGenerator
             // produced by this stitch
             if (IsStitchHeld(baseStitchIndex))
             {
-                return stitchInfo.held;
+                return (baseStitches.Length - stitchInfo.held);
             }
             return -stitchInfo.held;
         }
@@ -164,7 +149,7 @@ namespace YarnGenerator
             int loopProdducedIndex = 0;
             for (int baseStitchIndex=0; baseStitchIndex<baseStitches.Length; baseStitchIndex++)
             {
-                BaseStitch baseStitch = GetOrderedBaseStitch(baseStitchIndex);
+                BaseStitch baseStitch = baseStitches[baseStitchIndex];
 
                 for (int loopIndex = 0; loopIndex  < baseStitch.loopsProduced.Length; loopIndex++)
                 {

--- a/KnittingChartPreview/Assets/Scripts/StitchInfo.cs
+++ b/KnittingChartPreview/Assets/Scripts/StitchInfo.cs
@@ -59,10 +59,6 @@ namespace YarnGenerator
                     return new Cable1Ro2LStitch();
                 case StitchType.Cable2Lo2RStitch:
                     return new Cable2Lo2RStitch();
-                case StitchType.CableKnitStitch:
-                    return new CableKnitStitch();
-                case StitchType.CableKnitStitch4:
-                    return new CableKnitStitch4();
                 case StitchType.Knit2TogStitch:
                     return new Knit2TogStitch();
                 case StitchType.SSKStitch:
@@ -259,41 +255,6 @@ namespace YarnGenerator
             this.holdDirection = HoldDirection.Front;
             BaseStitchType[] baseStitchTypeList = new BaseStitchType[]
             {
-                BaseStitchType.Knit,
-                BaseStitchType.Knit,
-                BaseStitchType.Knit
-            };
-            this.baseStitchInfoList = GetBaseStitchInfoList(baseStitchTypeList);
-        }
-    }
-    
-    public class CableKnitStitch : StitchInfo
-    {
-        public CableKnitStitch() : base()
-        {
-            this.stitchType = StitchType.CableKnitStitch;
-            this.nBaseStitches = 2;
-            this.nLoopsConsumed = 2;
-            this.nLoopsProduced = 2;
-            BaseStitchType[] baseStitchTypeList = new BaseStitchType[2]
-            {
-                BaseStitchType.Knit,
-                BaseStitchType.Knit
-            };
-            this.baseStitchInfoList = GetBaseStitchInfoList(baseStitchTypeList);
-        }
-    }
-    
-    public class CableKnitStitch4 : StitchInfo
-    {
-        public CableKnitStitch4() : base()
-        {
-            this.stitchType = StitchType.CableKnitStitch4;
-            this.nBaseStitches = 4;
-            this.nLoopsConsumed = 4;
-            this.nLoopsProduced = 4;
-            BaseStitchType[] baseStitchTypeList = new BaseStitchType[4] {
-                BaseStitchType.Knit,
                 BaseStitchType.Knit,
                 BaseStitchType.Knit,
                 BaseStitchType.Knit

--- a/KnittingChartPreview/Assets/Scripts/StitchInfo.cs
+++ b/KnittingChartPreview/Assets/Scripts/StitchInfo.cs
@@ -256,7 +256,7 @@ namespace YarnGenerator
             this.nLoopsConsumed = 3;
             this.nLoopsProduced = 3;
             this.held = 1;
-            this.holdDirection = HoldDirection.Back;
+            this.holdDirection = HoldDirection.Front;
             BaseStitchType[] baseStitchTypeList = new BaseStitchType[]
             {
                 BaseStitchType.Knit,

--- a/KnittingChartPreview/Assets/Scripts/StitchType.cs
+++ b/KnittingChartPreview/Assets/Scripts/StitchType.cs
@@ -11,8 +11,6 @@ namespace YarnGenerator
         YarnOverStitch,
         Cable1Lo1RStitch,
         Cable2Lo2RStitch,
-        CableKnitStitch,
-        CableKnitStitch4,
         Cable1Ro2LStitch
     }
 }


### PR DESCRIPTION
There was a bug in how the cable stitches were being generated.

Specifically, the produced loops from the base stitches were not being returned in the correct order.  This was resolved, and the cable stitches now work as expected.

Note that to compensate for this bug, previously, I had introduced cable stitches with no held stitches.  These have been removed, as we don't expect them to be used.